### PR TITLE
update to zig 0.4.0+fa42c99d

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -12,7 +12,7 @@ const Target = struct {
     cflags: []const u8,
 };
 
-const targets = []Target{
+const targets = [_]Target{
     Target{
         .name = "k-nucleotide",
         .libs = "c",
@@ -86,7 +86,7 @@ const CreateDirStep = struct {
         const self = @fieldParentPtr(CreateDirStep, "step", step);
 
         const full_path = self.builder.pathFromRoot(self.dir_path);
-        std.os.makeDir(full_path) catch |err| {
+        std.fs.makeDir(full_path) catch |err| {
             if (self.allow_existing and err == error.PathAlreadyExists) {
                 return;
             }
@@ -104,8 +104,7 @@ fn addCreateDirStep(self: *Builder, dir_path: []const u8, allow_existing: bool) 
 }
 
 pub fn build(b: *Builder) !void {
-    var direct = std.heap.DirectAllocator.init();
-    var allocator = &direct.allocator;
+    const allocator = std.heap.direct_allocator;
 
     const create_build_dir = addCreateDirStep(b, build_path, true);
     const create_build_c_dir = addCreateDirStep(b, build_path_c, true);

--- a/src/binary-trees.zig
+++ b/src/binary-trees.zig
@@ -54,7 +54,7 @@ pub fn main() !void {
     var stdout_out_stream = stdout_file.outStream();
     const stdout = &stdout_out_stream.stream;
 
-    var args = std.os.args();
+    var args = std.process.args();
     _ = args.skip();
     const n = try std.fmt.parseUnsigned(u8, try args.next(allocator).?, 10);
 

--- a/src/fannkuch-redux.zig
+++ b/src/fannkuch-redux.zig
@@ -9,7 +9,7 @@ pub fn main() !void {
     var stdout_out_stream = stdout_file.outStream();
     var stdout = &stdout_out_stream.stream;
 
-    var args = std.os.args();
+    var args = std.process.args();
     _ = args.skip();
     const n = try std.fmt.parseUnsigned(u8, try args.next(allocator).?, 10);
 

--- a/src/fasta.zig
+++ b/src/fasta.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 const OutStream = std.io.OutStream;
-const File = std.os.File;
+const File = std.fs.File;
 
 const max_line_length = 60;
 
@@ -30,8 +30,8 @@ fn repeatAndWrap(out: *OutStream(File.WriteError), comptime sequence: []const u8
         const rem = count - idx;
         const line_length = std.math.min(usize(max_line_length), rem);
 
-        _ = out.write(padded_sequence[off .. off + line_length]);
-        _ = out.writeByte('\n');
+        _ = out.write(padded_sequence[off .. off + line_length]) catch {};
+        _ = out.writeByte('\n') catch {};
 
         off += line_length;
         if (off > sequence.len) {
@@ -71,7 +71,7 @@ fn generateAndWrap(out: *OutStream(File.WriteError), comptime nucleotides: []con
         }
 
         line[line_length] = '\n';
-        _ = out.write(line[0 .. line_length + 1]);
+        _ = out.write(line[0 .. line_length + 1]) catch {};
         idx += line_length;
     }
 }
@@ -83,11 +83,11 @@ var allocator = &fixed_allocator.allocator;
 pub fn main() !void {
     var stdout_file = try std.io.getStdOut();
     var stdout_out_stream = stdout_file.outStream();
-    var buffered_stdout = std.io.BufferedOutStream(std.os.File.OutStream.Error).init(&stdout_out_stream.stream);
-    defer _ = buffered_stdout.flush();
+    var buffered_stdout = std.io.BufferedOutStream(std.fs.File.OutStream.Error).init(&stdout_out_stream.stream);
+    defer _ = buffered_stdout.flush() catch {};
     var stdout = &buffered_stdout.stream;
 
-    var args = std.os.args();
+    var args = std.process.args();
     _ = args.skip();
     const n = try std.fmt.parseUnsigned(u64, try args.next(allocator).?, 10);
 
@@ -98,7 +98,7 @@ pub fn main() !void {
     try stdout.write(">ONE Homo sapiens alu\n");
     repeatAndWrap(stdout, homo_sapiens_alu, 2 * n);
 
-    const iub_nucleotide_info = []const AminoAcid{
+    const iub_nucleotide_info = [_]AminoAcid{
         AminoAcid{ .l = 'a', .p = 0.27 },
         AminoAcid{ .l = 'c', .p = 0.12 },
         AminoAcid{ .l = 'g', .p = 0.12 },
@@ -118,7 +118,7 @@ pub fn main() !void {
     try stdout.write(">TWO IUB ambiguity codes\n");
     generateAndWrap(stdout, iub_nucleotide_info, 3 * n);
 
-    const homo_sapien_nucleotide_info = []const AminoAcid{
+    const homo_sapien_nucleotide_info = [_]AminoAcid{
         AminoAcid{ .l = 'a', .p = 0.3029549426680 },
         AminoAcid{ .l = 'c', .p = 0.1979883004921 },
         AminoAcid{ .l = 'g', .p = 0.1975473066391 },

--- a/src/k-nucleotide.zig
+++ b/src/k-nucleotide.zig
@@ -3,7 +3,7 @@ const std = @import("std");
 const HashMap = std.HashMap(u64, u32, std.hash_map.getAutoHashFn(u64), std.hash_map.getAutoEqlFn(u64));
 
 inline fn codeForNucleotide(nucleotide: u8) u8 {
-    const lookup = []const u8{ ' ', 0, ' ', 1, 3, ' ', ' ', 2 };
+    const lookup = [_]u8{ ' ', 0, ' ', 1, 3, ' ', ' ', 2 };
     return lookup[nucleotide & 0x7];
 }
 
@@ -61,7 +61,7 @@ fn generateFrequenciesForLength(allocator: *std.mem.Allocator, poly: []const u8,
 
         const slice = try std.fmt.bufPrint(
             output[position..],
-            "{} {.3}\n",
+            "{} {:.3}\n",
             olig[0..],
             100.0 * @intToFloat(f64, entry.value) / @intToFloat(f64, poly.len - desired_length + 1),
         );
@@ -109,13 +109,13 @@ pub fn main() !void {
 
     var stdout_file = try std.io.getStdOut();
     var stdout_out_stream = stdout_file.outStream();
-    var buffered_stdout = std.io.BufferedOutStream(std.os.File.OutStream.Error).init(&stdout_out_stream.stream);
-    defer _ = buffered_stdout.flush();
+    var buffered_stdout = std.io.BufferedOutStream(std.fs.File.OutStream.Error).init(&stdout_out_stream.stream);
+    defer _ = buffered_stdout.flush() catch {};
     var stdout = &buffered_stdout.stream;
 
     var stdin_file = try std.io.getStdIn();
     var stdin_in_stream = stdin_file.inStream();
-    var buffered_stdin = std.io.BufferedInStream(std.os.File.InStream.Error).init(&stdin_in_stream.stream);
+    var buffered_stdin = std.io.BufferedInStream(std.fs.File.InStream.Error).init(&stdin_in_stream.stream);
     var stdin = &buffered_stdin.stream;
 
     var buffer: [4096]u8 = undefined;
@@ -143,8 +143,8 @@ pub fn main() !void {
 
     const poly_shrunk = poly.toOwnedSlice();
 
-    const counts = []u8{ 1, 2 };
-    const entries = [][]const u8{ "GGT", "GGTA", "GGTATT", "GGTATTTTAATT", "GGTATTTTAATTTATAGT" };
+    const counts = [_]u8{ 1, 2 };
+    const entries = [_][]const u8{ "GGT", "GGTA", "GGTATT", "GGTATTTTAATT", "GGTATTTTAATTTATAGT" };
 
     var output: [counts.len + entries.len][4096]u8 = undefined;
 

--- a/src/mandelbrot.zig
+++ b/src/mandelbrot.zig
@@ -7,11 +7,11 @@ var allocator = &fixed_allocator.allocator;
 pub fn main() !void {
     var stdout_file = try std.io.getStdOut();
     var stdout_out_stream = stdout_file.outStream();
-    var buffered_stdout = std.io.BufferedOutStream(std.os.File.OutStream.Error).init(&stdout_out_stream.stream);
-    defer _ = buffered_stdout.flush();
+    var buffered_stdout = std.io.BufferedOutStream(std.fs.File.OutStream.Error).init(&stdout_out_stream.stream);
+    defer _ = buffered_stdout.flush() catch {};
     var stdout = &buffered_stdout.stream;
 
-    var args = std.os.args();
+    var args = std.process.args();
     _ = args.skip();
     const w = try std.fmt.parseUnsigned(usize, try args.next(allocator).?, 10);
     const h = w;

--- a/src/n-body.zig
+++ b/src/n-body.zig
@@ -82,7 +82,7 @@ fn offset_momentum(bodies: []Planet) void {
     sun.vz = -pz / solar_mass;
 }
 
-const solar_bodies = []const Planet{
+const solar_bodies = [_]Planet{
     // Sun
     Planet{
         .x = 0.0,
@@ -144,15 +144,15 @@ pub fn main() !void {
     var stdout_out_stream = stdout_file.outStream();
     const stdout = &stdout_out_stream.stream;
 
-    var args = std.os.args();
+    var args = std.process.args();
     _ = args.skip();
     const n = try std.fmt.parseUnsigned(u64, try args.next(allocator).?, 10);
 
     var bodies = solar_bodies;
 
     offset_momentum(bodies[0..]);
-    try stdout.print("{.9}\n", energy(bodies[0..]));
+    try stdout.print("{:.9}\n", energy(bodies[0..]));
 
     advance(bodies[0..], 0.01, n);
-    try stdout.print("{.9}\n", energy(bodies[0..]));
+    try stdout.print("{:.9}\n", energy(bodies[0..]));
 }

--- a/src/pidigits.zig
+++ b/src/pidigits.zig
@@ -42,11 +42,11 @@ fn nextTerm(k: usize) void {
 pub fn main() !void {
     var stdout_file = try std.io.getStdOut();
     var stdout_out_stream = stdout_file.outStream();
-    var buffered_stdout = std.io.BufferedOutStream(std.os.File.OutStream.Error).init(&stdout_out_stream.stream);
-    defer _ = buffered_stdout.flush();
+    var buffered_stdout = std.io.BufferedOutStream(std.fs.File.OutStream.Error).init(&stdout_out_stream.stream);
+    defer _ = buffered_stdout.flush() catch {};
     var stdout = &buffered_stdout.stream;
 
-    var args = std.os.args();
+    var args = std.process.args();
     _ = args.skip();
     const n = try std.fmt.parseUnsigned(usize, try args.next(std.heap.c_allocator).?, 10);
 

--- a/src/regex-redux.zig
+++ b/src/regex-redux.zig
@@ -33,7 +33,7 @@ fn substitute(dst: *std.ArrayList(u8), src: []const u8, pattern: [*]const u8, re
         const upos = @intCast(usize, pos);
         const clen = @intCast(usize, m[0]) - upos;
         try dst.appendSlice(src[upos .. upos + clen]);
-        try dst.appendSlice(std.cstr.toSliceConst(replacement));
+        try dst.appendSlice(std.mem.toSliceConst(u8, replacement));
     }
 
     const upos = @intCast(usize, pos);
@@ -55,7 +55,7 @@ fn countMatches(src: []const u8, pattern: [*]const u8) !usize {
     return count;
 }
 
-const variants = [][*]const u8{
+const variants = [_][*]const u8{
     c"agggtaaa|tttaccct",
     c"[cgt]gggtaaa|tttaccc[acg]",
     c"a[act]ggtaaa|tttacc[agt]t",
@@ -67,12 +67,12 @@ const variants = [][*]const u8{
     c"agggtaa[cgt]|[acg]ttaccct",
 };
 
-const subs = [][*]const u8{
-    c"tHa[Nt]", c"<4>",
+const subs = [_][*]const u8{
+    c"tHa[Nt]",            c"<4>",
     c"aND|caN|Ha[DS]|WaS", c"<3>",
-    c"a[NSt]|BY", c"<2>",
-    c"<[^>]*>", c"|",
-    c"\\|[^|][^|]*\\|", c"-",
+    c"a[NSt]|BY",          c"<2>",
+    c"<[^>]*>",            c"|",
+    c"\\|[^|][^|]*\\|",    c"-",
 };
 
 pub fn main() !void {

--- a/src/reverse-complement.zig
+++ b/src/reverse-complement.zig
@@ -62,7 +62,7 @@ pub fn main() !void {
 
     var stdin_file = try std.io.getStdIn();
     var stdin_in_stream = stdin_file.inStream();
-    var buffered_stdin = std.io.BufferedInStream(std.os.File.InStream.Error).init(&stdin_in_stream.stream);
+    var buffered_stdin = std.io.BufferedInStream(std.fs.File.InStream.Error).init(&stdin_in_stream.stream);
     var stdin = &buffered_stdin.stream;
 
     const buf = try stdin.readAllAlloc(allocator, std.math.maxInt(usize));

--- a/src/spectral-norm.zig
+++ b/src/spectral-norm.zig
@@ -29,14 +29,14 @@ fn eval_ata_times_u(atau: []f64, u: []const f64, scratch: []f64) void {
     eval_a_times_u(true, atau, scratch);
 }
 
-var allocator = &std.heap.DirectAllocator.init().allocator;
+const allocator = std.heap.direct_allocator;
 
 pub fn main() !void {
     var stdout_file = try std.io.getStdOut();
     var stdout_out_stream = stdout_file.outStream();
     const stdout = &stdout_out_stream.stream;
 
-    var args = std.os.args();
+    var args = std.process.args();
     _ = args.skip();
     const n = try std.fmt.parseUnsigned(u64, try args.next(allocator).?, 10);
 
@@ -63,5 +63,5 @@ pub fn main() !void {
         vv += v[i] * v[i];
     }
 
-    try stdout.print("{.9}\n", std.math.sqrt(vbv / vv));
+    try stdout.print("{:.9}\n", std.math.sqrt(vbv / vv));
 }


### PR DESCRIPTION
By the way, it might be nicer to avoid `setOutputDir` in the build script and instead rely on the install target. This would allow the build system to do caching. I'm planning on making the install target the default, so that would be a future-friendly change to make.